### PR TITLE
fix callback arguments on compile, so we trigger dependencies correctly

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ JadeCompiler.prototype.extension = 'jade';
 
 JadeCompiler.prototype.compile = function(data, filepath, callback) {
   var options = clone(this.options);
-  var html, result, buildPath, buildDir;
+  var html, buildPath, buildDir;
 
   buildPath = this.buildPath(filepath);
   buildDir = sysPath.dirname(buildPath);
@@ -56,11 +56,11 @@ JadeCompiler.prototype.compile = function(data, filepath, callback) {
         callback(err, null);
       } else {
         fs.writeFileSync(buildPath, html);
-        callback(err, result);
+        callback(null, '');
       }
     });
   } catch (err) {
-    callback(err, result);
+    callback(err, null);
   }
 };
 


### PR DESCRIPTION
After about an hour debugging why brunch wasn't picking up changes on my include files :wink: I realised you're calling the callback with invalid arguments. By returning (null, '') we trigger getDependencies correctly.
